### PR TITLE
Add workflow for gh pages deploy (#28)

### DIFF
--- a/.github/workflows/deploGHPages.yaml
+++ b/.github/workflows/deploGHPages.yaml
@@ -1,0 +1,36 @@
+name: Deploy to github Pages
+
+on:
+  push:
+    branches: [ master ]
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-deploy:
+    concurrency: ci-${{ github.ref }} # Recommended if you intend to make multiple deployments in quick succession.
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x]
+
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install and Build 🔧 # This example project is built using npm and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
+        run: |
+          npm ci
+          npm run build
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: build # The folder the action should deploy.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "color",
   "version": "0.1.0",
   "private": true,
+  "homepage": "https://SscSPs.github.io/color",
   "dependencies": {
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^11.2.7",


### PR DESCRIPTION
* Add workflow and dependency for gh pages deploy

Signed-off-by: Sahil Soni <SscSPs@gmail.com>

* Use Only the workflow https://github.com/marketplace/actions/deploy-to-github-pages

Signed-off-by: Sahil Soni <SscSPs@gmail.com>

* Add master push to deply trigger

Signed-off-by: Sahil Soni <SscSPs@gmail.com>

* Remove extra trigger

Signed-off-by: Sahil Soni <SscSPs@gmail.com>

* Add homepage to package.json

Signed-off-by: Sahil Soni <SscSPs@gmail.com>

Signed-off-by: Sahil Soni <SscSPs@gmail.com>