### PR TITLE
Add "#" to copied color code issue fix

### DIFF
--- a/src/ColorGrid.js
+++ b/src/ColorGrid.js
@@ -54,7 +54,7 @@ const ColorGrid = ({ hueValue, saturationCount, luminosityCount }) => {
                       });
                       return (
                         <div key={luminosityStep} style={styles.swatch}>
-                          <div style={styles.color} className="color-cell" onClick={() => { navigator.clipboard.writeText(hexColour) }}>
+                          <div style={styles.color} className="color-cell" onClick={() => { navigator.clipboard.writeText(`#${hexColour}`) }}>
                             <p>{hexColour}</p>
                           </div>
                         </div>


### PR DESCRIPTION
After copying the color code, now "#" is being copied in front of it.