### PR TITLE
add styling for mobile version

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -25,6 +25,16 @@
   display: grid;
   place-items: center;
   font-size: 12px;
+  border-radius: 5px;
+}
+
+.color-cell-wrapper {
+  padding: 1px;
+  background: #fff;
+  border-radius: 5px;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
+  display: inline-block;
+  cursor: pointer;
 }
 
 .color-cell p {
@@ -157,4 +167,19 @@
 
 html {
   overflow-x: hidden;
+}
+
+@media (max-width: 800px) {
+  .main {
+    width: 100%;
+    background: rgba(255, 255, 255, 0.1);
+  }
+
+  .color-cell-wrapper {
+    border-radius: 50%;
+  }
+
+  .color-cell {
+    border-radius: 50%;
+  }
 }

--- a/src/ColorGrid.js
+++ b/src/ColorGrid.js
@@ -10,9 +10,13 @@ const ColorGrid = ({ hueValue, saturationCount, luminosityCount }) => {
   const saturationFraction = 100 / (saturationCount - 2);
   const luminosityFraction = 100 / (luminosityCount - 2);
 
-  const oneColorWidth = width / (saturationCount - 2) / 2;
-  const oneColorHeight = height / (luminosityCount - 2) / 2;
+  let oneColorWidth = width / (saturationCount - 2) / 2;
+  let oneColorHeight = height / (luminosityCount - 2) / 2;
 
+  if (oneColorWidth < 40) {
+    oneColorHeight = 40;
+    oneColorWidth = 40;
+  }
   return (
     <div
       className='colorgrid'
@@ -46,22 +50,16 @@ const ColorGrid = ({ hueValue, saturationCount, luminosityCount }) => {
                           color: {
                             width: `${oneColorWidth}px`,
                             height: `${oneColorHeight}px`,
-                            borderRadius: '5px',
                             background: `hsl(${hueLocal}, ${saturationLocal}%, ${luminosityLocal}%)`,
                             color: luminosityLocal > 50 ? '#000' : '#fff',
-                          },
-                          swatch: {
-                            padding: '1px',
-                            background: '#fff',
-                            borderRadius: '5px',
-                            boxShadow: '0 0 0 1px rgba(0,0,0,.1)',
-                            display: 'inline-block',
-                            cursor: 'pointer',
                           },
                         },
                       });
                       return (
-                        <div key={luminosityStep} style={styles.swatch}>
+                        <div
+                          key={luminosityStep}
+                          className='color-cell-wrapper'
+                        >
                           <div
                             style={styles.color}
                             className='color-cell'
@@ -75,9 +73,8 @@ const ColorGrid = ({ hueValue, saturationCount, luminosityCount }) => {
                                   toast.error('Failed to copy');
                                 });
                             }}
-                          >
-                            <p>#{hexColour}</p>
-                          </div>
+                            title={`#${hexColour}`}
+                          />
                         </div>
                       );
                     })


### PR DESCRIPTION
Gave some styling for mobile version:
before:
![2](https://user-images.githubusercontent.com/95734284/195154936-3db6ebdd-87e8-4068-b414-fb108df78b6f.png)
after:
![1](https://user-images.githubusercontent.com/95734284/195155026-88aa0ffa-85b6-4a4b-bbb6-c381e94b878b.png)
